### PR TITLE
Change name of gay filter to rainbow

### DIFF
--- a/doc/toilet.1.in
+++ b/doc/toilet.1.in
@@ -93,17 +93,17 @@ Set the output width to the terminal width.
 .TP
 .B \-F, \-\-filter list
 .TP
-.B \-\-gay, \-\-metal
+.B \-\-rainbow, \-\-metal
 .PD
 Specify a list of filters to be applied to the output.
 .I <filters>
 is a colon-separated list of filters such as
-.I crop:rotate:gay
+.I crop:rotate:rainbow
 and the special argument
 .I list
 outputs a list of available filters.
 
-.B \-\-gay
+.B \-\-rainbow
 and
 .B \-\-metal
 are shortcuts to commonly used filters that are guaranteed to exist. Several
@@ -153,7 +153,7 @@ toilet Hello World
 
 toilet Hello | toilet
 
-tail -f /var/log/messages | toilet -f term --gay
+tail -f /var/log/messages | toilet -f term --rainbow
 .RI
 .SH BUGS
 .B FIGlet

--- a/src/filter.c
+++ b/src/filter.c
@@ -28,7 +28,7 @@
 #include "filter.h"
 
 static void filter_crop(context_t *);
-static void filter_gay(context_t *);
+static void filter_rainbow(context_t *);
 static void filter_metal(context_t *);
 static void filter_flip(context_t *);
 static void filter_flop(context_t *);
@@ -46,7 +46,7 @@ struct
 const lookup[] =
 {
     { "crop", filter_crop, "crop unused blanks" },
-    { "gay", filter_gay, "add a rainbow colour effect" },
+    { "rainbow", filter_rainbow, "add a rainbow colour effect" },
     { "metal", filter_metal, "add a metallic colour effect" },
     { "flip", filter_flip, "flip horizontally" },
     { "flop", filter_flop, "flip vertically" },
@@ -185,7 +185,7 @@ static void filter_metal(context_t *cx)
     }
 }
 
-static void filter_gay(context_t *cx)
+static void filter_rainbow(context_t *cx)
 {
     static unsigned char const rainbow[] =
     {

--- a/src/main.c
+++ b/src/main.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
             { "width", 1, NULL, 'w' },
             { "termwidth", 0, NULL, 't' },
             { "filter", 1, NULL, 'F' },
-            { "gay", 0, NULL, 130 },
+            { "rainbow", 0, NULL, 130 },
             { "metal", 0, NULL, 131 },
             { "export", 1, NULL, 'E' },
             { "irc", 0, NULL, 140 },
@@ -104,8 +104,8 @@ int main(int argc, char *argv[])
             if(filter_add(cx, caca_optarg) < 0)
                 return -1;
             break;
-        case 130: /* --gay */
-            filter_add(cx, "gay");
+        case 130: /* --rainbow */
+            filter_add(cx, "rainbow");
             break;
         case 131: /* --metal */
             filter_add(cx, "metal");
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
     "  -t, --termwidth          adapt to terminal's width\n" \
     "  -F, --filter <filters>   apply one or several filters to the text\n" \
     "  -F, --filter list        list available filters\n" \
-    "      --gay                rainbow filter (same as -F gay)\n" \
+    "      --rainbow                rainbow filter (same as -F rainbow)\n" \
     "      --metal              metal filter (same as -F metal)\n" \
     "  -E, --export <format>    select export format\n" \
     "  -E, --export list        list available export formats\n" \

--- a/src/main.c
+++ b/src/main.c
@@ -65,8 +65,9 @@ int main(int argc, char *argv[])
             { "width", 1, NULL, 'w' },
             { "termwidth", 0, NULL, 't' },
             { "filter", 1, NULL, 'F' },
-            { "rainbow", 0, NULL, 130 },
+            { "gay", 0, NULL, 130 },
             { "metal", 0, NULL, 131 },
+            { "rainbow", 0, NULL, 132 },
             { "export", 1, NULL, 'E' },
             { "irc", 0, NULL, 140 },
             { "html", 0, NULL, 141 },
@@ -104,11 +105,14 @@ int main(int argc, char *argv[])
             if(filter_add(cx, caca_optarg) < 0)
                 return -1;
             break;
-        case 130: /* --rainbow */
+        case 130: /* --gay (alias to rainbow)*/
             filter_add(cx, "rainbow");
             break;
         case 131: /* --metal */
             filter_add(cx, "metal");
+            break;
+        case 132: /* --rainbow */
+            filter_add(cx, "rainbow");
             break;
         case 'w': /* --width */
             cx->term_width = atoi(caca_optarg);
@@ -213,7 +217,7 @@ int main(int argc, char *argv[])
     "  -t, --termwidth          adapt to terminal's width\n" \
     "  -F, --filter <filters>   apply one or several filters to the text\n" \
     "  -F, --filter list        list available filters\n" \
-    "      --rainbow                rainbow filter (same as -F rainbow)\n" \
+    "      --rainbow            rainbow filter (same as -F rainbow)\n" \
     "      --metal              metal filter (same as -F metal)\n" \
     "  -E, --export <format>    select export format\n" \
     "  -E, --export list        list available export formats\n" \


### PR DESCRIPTION
I use toilet at work for some stuff - the `--gay` filter adds appropriate whimsy.  I like it.
However, `--rainbow` would be better.
