### PR TITLE
Add -l|--list option to list fonts in active directories

### DIFF
--- a/src/figlet.c
+++ b/src/figlet.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <dirent.h>
 #include <caca.h>
 
 #include "toilet.h"
@@ -33,6 +34,37 @@
 static int feed_figlet(context_t *, uint32_t, uint32_t);
 static int flush_figlet(context_t *);
 static int end_figlet(context_t *);
+
+void list_dir_fonts(char const *dir)
+{
+    DIR *d;
+    struct dirent *dr;
+    int n = 0;
+    d = opendir(dir);
+    while(d && (dr = readdir(d)) != NULL)
+    {
+        size_t len = strlen(dr->d_name);
+        if(len<5)
+            continue;
+        if(!strcmp(dr->d_name + len - 4, ".flf") || !strcmp(dr->d_name + len - 4, ".tlf"))
+        {
+            if(!n++)
+                printf("- %s:", dir);
+            printf(" %s", dr->d_name);
+        }
+    }
+    if(n)
+        printf("\n");
+    closedir(d);
+}
+
+int list_fonts(char const *dir)
+{
+    list_dir_fonts(dir);
+    if(strcmp(dir, getenv("PWD")))
+        list_dir_fonts(getenv("PWD"));
+    return 0;
+}
 
 int init_figlet(context_t *cx)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -49,6 +49,7 @@ int main(int argc, char *argv[])
     cx->term_width = 80;
 
     cx->hmode = "default";
+    cx->list = 0;
 
     cx->filters = NULL;
     cx->nfilters = 0;
@@ -63,6 +64,7 @@ int main(int argc, char *argv[])
             { "font", 1, NULL, 'f' },
             { "directory", 1, NULL, 'd' },
             { "width", 1, NULL, 'w' },
+            { "list", 0, NULL, 'l' },
             { "termwidth", 0, NULL, 't' },
             { "filter", 1, NULL, 'F' },
             { "gay", 0, NULL, 130 },
@@ -77,7 +79,7 @@ int main(int argc, char *argv[])
             { NULL, 0, NULL, 0 }
         };
 
-        int c = caca_getopt(argc, argv, "f:d:w:tsSkWoF:E:hI:v",
+        int c = caca_getopt(argc, argv, "f:d:w:tsSkWolF:E:hI:v",
                             long_options, &option_index);
         if(c == -1)
             break;
@@ -144,6 +146,9 @@ int main(int argc, char *argv[])
         case 'o':
             cx->hmode = "overlap";
             break;
+        case 'l':
+            cx->list = 1;
+            break;
         case 'E': /* --export */
             if(!strcmp(caca_optarg, "list"))
                 return export_list();
@@ -189,6 +194,9 @@ int main(int argc, char *argv[])
             return 0;
     }
 
+    if(cx->list)
+        return list_fonts(cx->dir);
+
     if(render_init(cx) < 0)
         return -1;
 
@@ -204,13 +212,14 @@ int main(int argc, char *argv[])
 }
 
 #define USAGE \
-    "Usage: toilet [ -hkostvSW ] [ -d fontdirectory ]\n" \
+    "Usage: toilet [ -hklostvSW ] [ -d fontdirectory ]\n" \
     "              [ -f fontfile ] [ -F filter ] [ -w outputwidth ]\n" \
     "              [ -I infocode ] [ -E format ] [ message ]\n"
 
 #define HELP \
     "  -f, --font <name>        select the font\n" \
     "  -d, --directory <dir>    specify font directory\n" \
+    "  -l, --list               list available fonts in the active directories\n" \
     "  -s, -S, -k, -W, -o       render mode (default, force smushing,\n" \
     "                           kerning, full width, overlap)\n" \
     "  -w, --width <width>      set output width\n" \

--- a/src/render.h
+++ b/src/render.h
@@ -14,6 +14,8 @@
  * This header defines text to canvas rendering functions.
  */
 
+extern void list_dir_fonts(char const *);
+extern int list_fonts(char const *);
 extern int init_tiny(context_t *);
 extern int init_figlet(context_t *);
 

--- a/src/toilet.h
+++ b/src/toilet.h
@@ -19,6 +19,7 @@ struct toilet_context
     char const *export;
     char const *font;
     char const *dir;
+    char list;
 
     unsigned int term_width;
 


### PR DESCRIPTION
In separate functions, with proper return code usage in `main.c`, no `exit`, abiding by the coding style.