### PR TITLE
Rename --gay flag to --rainbow

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
             { "width", 1, NULL, 'w' },
             { "termwidth", 0, NULL, 't' },
             { "filter", 1, NULL, 'F' },
-            { "gay", 0, NULL, 130 },
+            { "rainbow", 0, NULL, 130 },
             { "metal", 0, NULL, 131 },
             { "rainbow", 0, NULL, 132 },
             { "export", 1, NULL, 'E' },
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
             if(filter_add(cx, caca_optarg) < 0)
                 return -1;
             break;
-        case 130: /* --gay (alias to rainbow)*/
+        case 130: /* --rainbow (alias to rainbow)*/
             filter_add(cx, "rainbow");
             break;
         case 131: /* --metal */
@@ -248,4 +248,3 @@ static void usage(void)
 {
     printf("%s%s", HELP, USAGE);
 }
-


### PR DESCRIPTION
Renames the `--gay` flag to `--rainbow` in the `src/main.c` file.

- Updates the `long_options` array to replace the `--gay` flag with `--rainbow`, ensuring consistency with the intended alias for the rainbow filter.
- Adjusts the case handling for the renamed flag in the command-line options parsing section, ensuring the application correctly interprets and applies the `--rainbow` flag when used.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cacalabs/toilet?shareId=b6ad79e6-f78e-49e8-b425-3c3b524dc0a0).